### PR TITLE
#1 상단 소문제 리스트를 위한 리스트 구현

### DIFF
--- a/src/components/problem/SelectableList.vue
+++ b/src/components/problem/SelectableList.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="list">
+  <div class="selectable-list">
     <div
       v-for="(item, index) in items"
       :key="index"
       :style="getLineStyle(index)"
-      class="itemContainer"
+      class="selectable-list__item"
       @click.stop="clickItem(item, index)"
       @mouseenter="updateHoverState(index, true)"
       @mouseleave="updateHoverState(index, false)"
@@ -13,7 +13,6 @@
         <!-- 대체 컨텐츠 -->
       </slot>
     </div>
-    <div style="clear:both"></div> <!-- float: left 로 인한 태그 및 스타일 -->
   </div>
 </template>
 
@@ -72,9 +71,14 @@
 </script>
 
 <style scoped>
-  .itemContainer {
-    float: left;
-    margin-left: 0.8em;
+  .selectable-list {
+    display: flex;
+  }
+  .selectable-list__item {
+    flex: initial;
     margin-right: 0.8em;
+  }
+  .selectable-list__item:last-child {
+    margin-right: 0;
   }
 </style>

--- a/src/components/problem/SelectableList.vue
+++ b/src/components/problem/SelectableList.vue
@@ -31,14 +31,13 @@
       lineSize: { //  under line 굵기
         required: true
       },
-      selectedIndex: { // 초기 선택 index - 초기에만 사용되고 변경 되어도 영향을 받지 않음
+      selectedIndex: { // 선택된 item 의 index
         type: Number,
-        default: 0
+        required: true
       }
     },
     data () {
       return {
-        local_selectedIndex: this.selectedIndex, // 선택된 아이템의 index
         hoverItemIndex: -1, // hover 된 아이템의 index
         blankLine: { // 선택되지 않았을 때 보여질 투명 라인
           borderBottom: this.lineSize + " solid #00000000"
@@ -50,7 +49,6 @@
     },
     methods: {
       clickItem (selectedItem, index) {
-        this.local_selectedIndex = index;
         this.$emit('selectChange', selectedItem, index);
       },
       updateHoverState (index, isHover) {
@@ -61,7 +59,7 @@
         }
       },
       isHighlighted (index) { // 선택 됐거나 hover 됐거나 값
-        return index === this.local_selectedIndex || index === this.hoverItemIndex;
+        return index === this.selectedIndex || index === this.hoverItemIndex;
       },
       getLineStyle (index) {
         return this.isHighlighted(index) ? this.underLine : this.blankLine;

--- a/src/components/problem/SelectableList.vue
+++ b/src/components/problem/SelectableList.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="list">
+    <div
+      v-for="(item, index) in items"
+      :key="index"
+      class="itemContainer"
+      :class="[{ selected: index === local_selectedIndex }]"
+      @click.stop="clickItem(item, index)"
+    >
+      <slot name="item" :element="item">
+        <!-- 대체 컨텐츠 -->
+      </slot>
+    </div>
+    <div style="clear:both"></div>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: {
+      items: {
+        type: Array,
+        required: true
+      },
+      selectedIndex: {
+        type: Number,
+        default: 0
+      }
+    },
+    data () {
+      return {
+        local_selectedIndex: this.selectedIndex, // 선택된 아이템의 index
+      }
+    },
+    methods: {
+      clickItem: function (selectedItem, index) {
+        this.local_selectedIndex = index;
+        this.$emit('selectChange', selectedItem, index);
+      }
+    }
+  }
+</script>
+
+<style scoped>
+  .itemContainer {
+    float: left;
+    margin-left: 0.8em;
+    margin-right: 0.8em;
+    border-bottom: 0.3em solid #00000000;
+  }
+  .itemContainer:hover {
+    border-bottom: 0.3em solid white;
+  }
+  .selected {
+    border-bottom: 0.3em solid white;
+  }
+</style>

--- a/src/components/problem/SelectableList.vue
+++ b/src/components/problem/SelectableList.vue
@@ -31,13 +31,15 @@
       lineSize: { //  under line 굵기
         required: true
       },
-      selectedIndex: { // 선택된 item 의 index
+      selectedIndex: { // 선택된 item 의 index - 초기 값
         type: Number,
-        required: true
+        default: -1,
+        required: false
       }
     },
     data () {
       return {
+        localSelectedIndex: this.selectedIndex,
         hoverItemIndex: -1, // hover 된 아이템의 index
         blankLine: { // 선택되지 않았을 때 보여질 투명 라인
           borderBottom: this.lineSize + " solid #00000000"
@@ -49,6 +51,7 @@
     },
     methods: {
       clickItem (selectedItem, index) {
+        this.localSelectedIndex = index;
         this.$emit('selectChange', selectedItem, index);
       },
       updateHoverState (index, isHover) {
@@ -59,7 +62,7 @@
         }
       },
       isHighlighted (index) { // 선택 됐거나 hover 됐거나 값
-        return index === this.selectedIndex || index === this.hoverItemIndex;
+        return index === this.localSelectedIndex || index === this.hoverItemIndex;
       },
       getLineStyle (index) {
         return this.isHighlighted(index) ? this.underLine : this.blankLine;

--- a/src/components/problem/SelectableList.vue
+++ b/src/components/problem/SelectableList.vue
@@ -3,15 +3,17 @@
     <div
       v-for="(item, index) in items"
       :key="index"
+      :style="getLineStyle(index)"
       class="itemContainer"
-      :class="[{ selected: index === local_selectedIndex }]"
       @click.stop="clickItem(item, index)"
+      @mouseenter="updateHoverState(index, true)"
+      @mouseleave="updateHoverState(index, false)"
     >
       <slot name="item" :element="item">
         <!-- 대체 컨텐츠 -->
       </slot>
     </div>
-    <div style="clear:both"></div>
+    <div style="clear:both"></div> <!-- float: left 로 인한 태그 및 스타일 -->
   </div>
 </template>
 
@@ -22,7 +24,14 @@
         type: Array,
         required: true
       },
-      selectedIndex: {
+      lineColor: { // under line 색
+        type: String,
+        required: true
+      },
+      lineSize: { //  under line 굵기
+        required: true
+      },
+      selectedIndex: { // 초기 선택 index - 초기에만 사용되고 변경 되어도 영향을 받지 않음
         type: Number,
         default: 0
       }
@@ -30,12 +39,32 @@
     data () {
       return {
         local_selectedIndex: this.selectedIndex, // 선택된 아이템의 index
+        hoverItemIndex: -1, // hover 된 아이템의 index
+        blankLine: { // 선택되지 않았을 때 보여질 투명 라인
+          borderBottom: this.lineSize + " solid #00000000"
+        },
+        underLine: { // 선택되었을 때 보여질 색이 있는 라인
+          borderBottom: this.lineSize + " solid " + this.lineColor
+        }
       }
     },
     methods: {
-      clickItem: function (selectedItem, index) {
+      clickItem (selectedItem, index) {
         this.local_selectedIndex = index;
         this.$emit('selectChange', selectedItem, index);
+      },
+      updateHoverState (index, isHover) {
+        if (isHover) {
+          this.hoverItemIndex = index;
+        } else if (index === this.hoverItemIndex) { // 비동기 호출을 대비한 최소한의 if
+          this.hoverItemIndex = -1;
+        }
+      },
+      isHighlighted (index) { // 선택 됐거나 hover 됐거나 값
+        return index === this.local_selectedIndex || index === this.hoverItemIndex;
+      },
+      getLineStyle (index) {
+        return this.isHighlighted(index) ? this.underLine : this.blankLine;
       }
     }
   }
@@ -46,12 +75,5 @@
     float: left;
     margin-left: 0.8em;
     margin-right: 0.8em;
-    border-bottom: 0.3em solid #00000000;
-  }
-  .itemContainer:hover {
-    border-bottom: 0.3em solid white;
-  }
-  .selected {
-    border-bottom: 0.3em solid white;
   }
 </style>

--- a/src/sample/problem/SelectableListSample.vue
+++ b/src/sample/problem/SelectableListSample.vue
@@ -1,5 +1,11 @@
 <template>
-  <selectable-list :items="items" lineColor="black" line-size="0.2em">
+  <selectable-list
+    :items="items"
+    :selectedIndex="selectedIndex"
+    lineColor="black"
+    line-size="0.2em"
+    @selectChange="selectChange"
+  >
     <div
       slot="item"
       slot-scope="props"
@@ -24,7 +30,13 @@
           { text : "3번문제" },
           { text : "4번문제" },
           { text : "5번문제" }
-        ]
+        ],
+        selectedIndex: 0
+      }
+    },
+    methods: {
+      selectChange (selectedItem, index) {
+        this.selectedIndex = index;
       }
     }
   }

--- a/src/sample/problem/SelectableListSample.vue
+++ b/src/sample/problem/SelectableListSample.vue
@@ -1,8 +1,8 @@
 <template>
   <selectable-list
     :items="items"
-    :selectedIndex="selectedIndex"
-    lineColor="black"
+    :selected-index="selectedIndex"
+    line-color="black"
     line-size="0.2em"
     @selectChange="selectChange"
   >

--- a/src/sample/problem/SelectableListSample.vue
+++ b/src/sample/problem/SelectableListSample.vue
@@ -1,0 +1,35 @@
+<template>
+  <selectable-list :items="items" lineColor="black" line-size="0.2em">
+    <div
+      slot="item"
+      slot-scope="props"
+    >
+      {{ props.element.text }}
+    </div>
+  </selectable-list>
+</template>
+
+<script>
+  import SelectableList from "@/components/problem/SelectableList";
+
+  export default {
+    components: {
+      SelectableList
+    },
+    data () {
+      return {
+        items: [
+          { text : "1번문제" },
+          { text : "2번문제" },
+          { text : "3번문제" },
+          { text : "4번문제" },
+          { text : "5번문제" }
+        ]
+      }
+    }
+  }
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
문제 페이지에서 상단 소문제 리스트를 위한 리스트를 구현했습니다.

각 item에 마우스를 가져다 대면 언더 라인이 그려지고 클릭하면 해당 item에 계속 언더 라인이 남습니다.

클릭할 경우 selecteChange 이벤트가 발생하고 선택되 item과 index를 매개변수로 넘깁니다.

예시 이미지
![image](https://user-images.githubusercontent.com/31586979/55671443-0232cd80-58cb-11e9-833f-a820fe325f38.png)