### PR TITLE
소단락(새끼) 문제 목록 페이지 구현 완료

### DIFF
--- a/src/components/main_problem/breadthumb/TopBreadthumb.vue
+++ b/src/components/main_problem/breadthumb/TopBreadthumb.vue
@@ -1,0 +1,24 @@
+<template lang="html">
+    <div id="main__breadthumb">
+        <sui-breadcrumb>
+            <sui-breadcrumb-section link>Home</sui-breadcrumb-section>
+            <sui-breadcrumb-divider icon="right chevron" />
+            <sui-breadcrumb-section link>{{ subject }}</sui-breadcrumb-section>
+            <sui-breadcrumb-divider icon="right chevron" />
+            <sui-breadcrumb-section active>{{ exam_title }}</sui-breadcrumb-section>
+        </sui-breadcrumb>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'top-breadthumb',
+    props: ['subject', 'exam_title']
+};
+</script>
+
+<style>
+#main__breadthumb {
+    margin: 30px 0px;
+}
+</style>

--- a/src/components/main_problem/breadthumb/TopBreadthumb.vue
+++ b/src/components/main_problem/breadthumb/TopBreadthumb.vue
@@ -13,7 +13,16 @@
 <script>
 export default {
     name: 'top-breadthumb',
-    props: ['subject', 'exam_title']
+    props: {
+        subject: {
+            type: String,
+            required: true
+        },
+        exam_title: {
+            type: String,
+            required: true
+        }
+    }
 };
 </script>
 

--- a/src/components/main_problem/problem/DetailUnit.vue
+++ b/src/components/main_problem/problem/DetailUnit.vue
@@ -1,0 +1,32 @@
+<template>
+    <sui-header-subheader>
+        <sui-icon :name="output_context.icon" /> 
+        <sui-header-content>
+            {{ output_context.context }}
+        </sui-header-content>
+    </sui-header-subheader>
+</template>
+
+<script>
+export default {
+    name: 'detail-unit',
+    props: ['checked', 'upload_cnt', 'reserve_date'],
+    computed: {
+        output_context() {
+            const { checked, upload_cnt, reserve_date } = this;
+            const start_time = reserve_date.getTime() - 90 * 60 * 1000;
+            if(checked){
+                return {
+                    icon: 'users',
+                    context: `${ upload_cnt } 명 제출했습니다.`
+                };
+            } else {
+                return {
+                    icon: 'clock outline',
+                    context: `${ new Date(start_time).toLocaleString() } 부터 진행`
+                }
+            }
+        }
+    }
+}
+</script>

--- a/src/components/main_problem/problem/MainElement.vue
+++ b/src/components/main_problem/problem/MainElement.vue
@@ -2,7 +2,7 @@
     <sui-segment :color="top_color" clearing>
         <h2 is="sui-header" floated="left">
             {{ problem.title }}
-            <sui-header-subheader v-if="new Date() >= problem.reserve_date">
+            <sui-header-subheader v-if="time_confirm.checked">
                 <sui-icon name="users" /> 
                 <sui-header-content>
                     {{ problem.upload_cnt }} 명 제출 했습니다.
@@ -16,14 +16,14 @@
             </sui-header-subheader>
         </h2>
         <h2 is="sui-header" floated="right" text-align="center">
-            <div v-if="new Date() >= problem.reserve_date">
+            <div v-if="time_confirm.checked">
                 {{ my_score }} / {{ problem.full_score }}
             </div>
             <div v-else>
                 {{ problem.full_score }} pt
             </div>
             <sui-header-subheader>
-                <sui-button :content="btn_context.context" :color="btn_context.color" @click="btn_context.action" />
+                <sui-button :content="time_confirm.context" :color="time_confirm.color" @click="time_confirm.action" />
             </sui-header-subheader>
         </h2>
     </sui-segment>
@@ -48,22 +48,25 @@ export default {
 
             return my_score / problem.full_score > 0.5 ? 'green' : 'red'; // 점수가 절반을 넘기면 초록색, 안 넘기면 빨간색으로 나오게 합니다.
         },
-        btn_context() {
+        time_confirm() {
             const { problem, type } = this;
             const now = new Date();
             const dist = problem.reserve_date.getTime() - now.getTime();
-            switch(type){
+            const checked = new Date() >= problem.reserve_date;
+            switch(type.value){
                 case 'TRAIN' :
                     return {
                         color: 'grey',
                         context: '실습하기',
-                        action: () => alert('실습 페이지')
+                        action: () => alert('실습 페이지'),
+                        checked
                     };
                 case 'HOMEWORK' :
                     return {
                         color: now < problem.reserve_date ? 'blue' : 'red',
                         context: now < problem.reserve_date ? '제출하기' : '제출 기한 초과',
-                        action: now < problem.reserve_date ? () => alert('과제 제출 페이지') : () => alert('과제 제출을 못 합니다.')
+                        action: now < problem.reserve_date ? () => alert('과제 제출 페이지') : () => alert('과제 제출을 못 합니다.'),
+                        checked
                     };
                 case 'EXAM' :
                     return {
@@ -79,6 +82,7 @@ export default {
                             (now < problem.reserve_date) ?
                                 (dist < 90 * 60 * 1000) ? () => alert('시험 접속 페이지') : () => alert('시험은 90분 이전에 시작 됩니다!')
                                 : () => alert('점수 조회 Collapse!'),
+                        checked
                     }
             }
         }

--- a/src/components/main_problem/problem/MainElement.vue
+++ b/src/components/main_problem/problem/MainElement.vue
@@ -2,12 +2,29 @@
     <sui-segment :color="top_color" clearing>
         <h2 is="sui-header" floated="left">
             {{ problem.title }}
-            <sui-header-subheader>
-                {{ problem.upload_cnt }} 명 제출 했습니다.
+            <sui-header-subheader v-if="new Date() >= problem.reserve_date">
+                <sui-icon name="users" /> 
+                <sui-header-content>
+                    {{ problem.upload_cnt }} 명 제출 했습니다.
+                </sui-header-content>
+            </sui-header-subheader>
+            <sui-header-subheader v-else>
+                <sui-icon name="clock outline" /> 
+                <sui-header-content>
+                    {{ problem.reserve_date.toLocaleString() }}
+                </sui-header-content>
             </sui-header-subheader>
         </h2>
-        <h2 is="sui-header" floated="right">
-            {{ my_score }} / {{ problem.full_score }}
+        <h2 is="sui-header" floated="right" text-align="center">
+            <div v-if="new Date() >= problem.reserve_date">
+                {{ my_score }} / {{ problem.full_score }}
+            </div>
+            <div v-else>
+                {{ problem.full_score }} pt
+            </div>
+            <sui-header-subheader>
+                <sui-button :content="btn_context.context" :color="btn_context.color" @click="btn_context.action" />
+            </sui-header-subheader>
         </h2>
     </sui-segment>
 </template>
@@ -15,7 +32,7 @@
 <script>
 export default {
     name: 'main-element',
-    props: ['problem', ],
+    props: ['problem', 'type', ],
     data() {
         return {
             my_score: 10, // 각 개인의 점수는 AJAX 를 사용해서 불러온다고 가정합니다.
@@ -24,11 +41,46 @@ export default {
     computed: {
         top_color() {
             const { my_score, problem } = this;
-            if(my_score === null) { // 현재 학생이 맞은 점수가 없으면 회색을 반환합니다.
+            const now = new Date();
+            if(my_score === null || now < problem.reserve_date) { // 현재 학생이 맞은 점수가 없으면 회색을 반환합니다.
                 return 'grey';
             }
 
             return my_score / problem.full_score > 0.5 ? 'green' : 'red'; // 점수가 절반을 넘기면 초록색, 안 넘기면 빨간색으로 나오게 합니다.
+        },
+        btn_context() {
+            const { problem, type } = this;
+            const now = new Date();
+            const dist = problem.reserve_date.getTime() - now.getTime();
+            switch(type){
+                case 'TRAIN' :
+                    return {
+                        color: 'grey',
+                        context: '실습하기',
+                        action: () => alert('실습 페이지')
+                    };
+                case 'HOMEWORK' :
+                    return {
+                        color: now < problem.reserve_date ? 'blue' : 'red',
+                        context: now < problem.reserve_date ? '제출하기' : '제출 기한 초과',
+                        action: now < problem.reserve_date ? () => alert('과제 제출 페이지') : () => alert('과제 제출을 못 합니다.')
+                    };
+                case 'EXAM' :
+                    return {
+                        color: 
+                            (now < problem.reserve_date) ?
+                                (dist < 90 * 60 * 1000) ? 'green' : 'yellow' // 시험 종료 90분 전에 접속 가능하게 합니다. 아니면 노란 버튼으로 접속 불가를 표기합니다.
+                                : 'blue', // 시험이 끝난 뒤에는 성적 공개 버튼으로 바꿉니다.
+                        context: 
+                            (now < problem.reserve_date) ?
+                                (dist < 90 * 60 * 1000) ? '시험 접속' : '접속 불가'
+                                : '점수 조회',
+                        action: 
+                            (now < problem.reserve_date) ?
+                                (dist < 90 * 60 * 1000) ? () => alert('시험 접속 페이지') : () => alert('시험은 90분 이전에 시작 됩니다!')
+                                : () => alert('점수 조회 Collapse!'),
+                    }
+            }
         }
     }
 }

--- a/src/components/main_problem/problem/MainElement.vue
+++ b/src/components/main_problem/problem/MainElement.vue
@@ -1,0 +1,38 @@
+<template>
+    <sui-segment :color="top_color" clearing>
+        <h2 is="sui-header" floated="left">
+            {{ problem.title }}
+            <sui-header-subheader>
+                {{ problem.upload_cnt }} 명 제출 했습니다.
+            </sui-header-subheader>
+        </h2>
+        <h2 is="sui-header" floated="right">
+            {{ my_score }} / {{ problem.full_score }}
+        </h2>
+    </sui-segment>
+</template>
+
+<script>
+export default {
+    name: 'main-element',
+    props: ['problem', ],
+    data() {
+        return {
+            my_score: 10, // 각 개인의 점수는 AJAX 를 사용해서 불러온다고 가정합니다.
+        }
+    },
+    computed: {
+        top_color() {
+            const { my_score, problem } = this;
+            if(my_score === null) { // 현재 학생이 맞은 점수가 없으면 회색을 반환합니다.
+                return 'grey';
+            }
+
+            return my_score / problem.full_score > 0.5 ? 'green' : 'red'; // 점수가 절반을 넘기면 초록색, 안 넘기면 빨간색으로 나오게 합니다.
+        }
+    }
+}
+</script>
+
+<style>
+</style>

--- a/src/components/main_problem/problem/MainElement.vue
+++ b/src/components/main_problem/problem/MainElement.vue
@@ -2,34 +2,24 @@
     <sui-segment :color="top_color" clearing>
         <h2 is="sui-header" floated="left">
             {{ problem.title }}
-            <sui-header-subheader v-if="time_confirm.checked">
-                <sui-icon name="users" /> 
-                <sui-header-content>
-                    {{ problem.upload_cnt }} 명 제출 했습니다.
-                </sui-header-content>
-            </sui-header-subheader>
-            <sui-header-subheader v-else>
-                <sui-icon name="clock outline" /> 
-                <sui-header-content>
-                    {{ problem.reserve_date.toLocaleString() }}
-                </sui-header-content>
-            </sui-header-subheader>
+            <detail-unit
+                :checked="time_confirm.checked"
+                :upload_cnt="problem.upload_cnt"
+                :reserve_date="problem.reserve_date"
+            ></detail-unit>
         </h2>
-        <h2 is="sui-header" floated="right" text-align="center">
-            <div v-if="time_confirm.checked">
-                {{ my_score }} / {{ problem.full_score }}
-            </div>
-            <div v-else>
-                {{ problem.full_score }} pt
-            </div>
-            <sui-header-subheader>
-                <sui-button :content="time_confirm.context" :color="time_confirm.color" @click="time_confirm.action" />
-            </sui-header-subheader>
-        </h2>
+        <score-unit 
+            :my_score="my_score"
+            :full_score="problem.full_score"
+            :time_confirm="time_confirm"
+        ></score-unit>
     </sui-segment>
 </template>
 
 <script>
+import ScoreUnit from './ScoreUnit';
+import DetailUnit from './DetailUnit';
+
 export default {
     name: 'main-element',
     props: ['problem', 'type', ],
@@ -37,6 +27,9 @@ export default {
         return {
             my_score: 10, // 각 개인의 점수는 AJAX 를 사용해서 불러온다고 가정합니다.
         }
+    },
+    components: {
+        ScoreUnit, DetailUnit
     },
     computed: {
         top_color() {

--- a/src/components/main_problem/problem/MainElement.vue
+++ b/src/components/main_problem/problem/MainElement.vue
@@ -2,81 +2,96 @@
     <sui-segment :color="top_color" clearing>
         <h2 is="sui-header" floated="left">
             {{ problem.title }}
-            <detail-unit
-                :checked="time_confirm.checked"
+            <time-uploader-unit
+                :checked="detail_data.checked"
                 :upload_cnt="problem.upload_cnt"
                 :reserve_date="problem.reserve_date"
-            ></detail-unit>
+            ></time-uploader-unit>
         </h2>
         <score-unit 
             :my_score="my_score"
             :full_score="problem.full_score"
-            :time_confirm="time_confirm"
+            :checked="detail_data.checked"
+            :btn_data="detail_data.btn_data"
         ></score-unit>
     </sui-segment>
 </template>
 
 <script>
 import ScoreUnit from './ScoreUnit';
-import DetailUnit from './DetailUnit';
+import TimeUploaderUnit from './TimeUploaderUnit';
 
 export default {
     name: 'main-element',
-    props: ['problem', 'type', ],
+    props: {
+        problem: {
+            type: Object,
+            required: true
+        },
+        type_code: {
+            type: String,
+            required: true
+        }
+    },
     data() {
         return {
-            my_score: 10, // 각 개인의 점수는 AJAX 를 사용해서 불러온다고 가정합니다.
+            my_score: 10, // 각 개인의 점수는 AJAX 를 사용해서 불러온다고 가정합니다. 요청은 문제 ID 와 학생 ID 로 조회하는 것입니다.
         }
     },
     components: {
-        ScoreUnit, DetailUnit
+        ScoreUnit, TimeUploaderUnit
     },
     computed: {
         top_color() {
             const { my_score, problem } = this;
             const now = new Date();
-            if(my_score === null || now < problem.reserve_date) { // 현재 학생이 맞은 점수가 없으면 회색을 반환합니다.
+            if(my_score === null) { // 현재 학생이 맞은 점수가 없으면. 즉 안 풀었으면 회색.
                 return 'grey';
+            } else if(now < problem.reserve_date) {
+                return 'yellow'; // 시험 종료 이전이면 색상을 공개 하지 않습니다.
+            } else { // 시험이 끝난 이후 점수가 나오면, 절반을 초과하면 초록색, 절반 이하는 빨간색으로 나오게 합니다.
+                return my_score / problem.full_score > 0.5 ? 'green' : 'red'; 
             }
-
-            return my_score / problem.full_score > 0.5 ? 'green' : 'red'; // 점수가 절반을 넘기면 초록색, 안 넘기면 빨간색으로 나오게 합니다.
         },
-        time_confirm() {
-            const { problem, type } = this;
+        detail_data() {
+            const { problem, type_code } = this;
             const now = new Date();
             const dist = problem.reserve_date.getTime() - now.getTime();
-            const checked = new Date() >= problem.reserve_date;
-            switch(type.value){
+            const detail_data = { 
+                checked : now >= problem.reserve_date, 
+            };
+            switch(type_code){
                 case 'TRAIN' :
-                    return {
-                        color: 'grey',
-                        context: '실습하기',
-                        action: () => alert('실습 페이지'),
-                        checked
-                    };
+                    return Object.assign(detail_data, { 
+                        btn_data : {
+                            color: 'grey', context: '실습하기', action: () => alert('실습 페이지 이동')
+                        }, 
+                    });
                 case 'HOMEWORK' :
-                    return {
-                        color: now < problem.reserve_date ? 'blue' : 'red',
-                        context: now < problem.reserve_date ? '제출하기' : '제출 기한 초과',
-                        action: now < problem.reserve_date ? () => alert('과제 제출 페이지') : () => alert('과제 제출을 못 합니다.'),
-                        checked
-                    };
+                    return Object.assign(detail_data, {
+                        btn_data : {
+                            color: now < problem.reserve_date ? 'blue' : 'red',
+                            context: now < problem.reserve_date ? '제출하기' : '제출 기한 초과', 
+                            action: now < problem.reserve_date ? () => alert('과제 제출 페이지') : () => alert('과제 제출을 못 합니다.')
+                        },
+                    });
                 case 'EXAM' :
-                    return {
-                        color: 
-                            (now < problem.reserve_date) ?
-                                (dist < 90 * 60 * 1000) ? 'green' : 'yellow' // 시험 종료 90분 전에 접속 가능하게 합니다. 아니면 노란 버튼으로 접속 불가를 표기합니다.
+                    return Object.assign(detail_data, {
+                        btn_data : {
+                            color: 
+                                (now < problem.reserve_date) ? 
+                                    (dist < 90 * 60 * 1000) ? 'green' : 'yellow' // 시험 종료 90분 전에 접속 가능하게 합니다. 아니면 노란 버튼으로 접속 불가를 표기합니다.
                                 : 'blue', // 시험이 끝난 뒤에는 성적 공개 버튼으로 바꿉니다.
-                        context: 
-                            (now < problem.reserve_date) ?
-                                (dist < 90 * 60 * 1000) ? '시험 접속' : '접속 불가'
+                            context: 
+                                (now < problem.reserve_date) ?
+                                    (dist < 90 * 60 * 1000) ? '시험 접속' : '접속 불가'
                                 : '점수 조회',
-                        action: 
-                            (now < problem.reserve_date) ?
-                                (dist < 90 * 60 * 1000) ? () => alert('시험 접속 페이지') : () => alert('시험은 90분 이전에 시작 됩니다!')
+                            action: 
+                                (now < problem.reserve_date) ?
+                                    (dist < 90 * 60 * 1000) ? () => alert('시험 접속 페이지') : () => alert('시험은 90분 이전에 시작 됩니다!')
                                 : () => alert('점수 조회 Collapse!'),
-                        checked
-                    }
+                        },
+                    });
             }
         }
     }

--- a/src/components/main_problem/problem/MainTitle.vue
+++ b/src/components/main_problem/problem/MainTitle.vue
@@ -1,0 +1,27 @@
+<template>
+    <sui-grid>
+        <sui-grid-column width="eight">
+            <h1 is="sui-header">
+                <sui-icon name="archive" />
+                <sui-header-content>{{ title }}</sui-header-content>
+            </h1>
+            <p>{{ context }}</p>
+        </sui-grid-column>
+        <sui-grid-column width="eight">
+            <h1 is="sui-header">
+                <sui-icon name="bell outline" />
+                <sui-header-content>제출기한</sui-header-content>
+            </h1>
+            <p>{{ limit_date }}</p>
+        </sui-grid-column>
+    </sui-grid>
+</template>
+
+<script>
+export default {
+    name: 'main-title',
+    props: [
+        'title', 'limit_date', 'context'
+    ],
+}
+</script>

--- a/src/components/main_problem/problem/MainTitle.vue
+++ b/src/components/main_problem/problem/MainTitle.vue
@@ -3,7 +3,10 @@
         <sui-grid-column width="eight">
             <h1 is="sui-header">
                 <sui-icon name="archive" />
-                <sui-header-content>{{ title }}</sui-header-content>
+                <sui-header-content>
+                    {{ title }}
+                    <sui-header-subheader>{{ unit_type }}</sui-header-subheader>
+                </sui-header-content>
             </h1>
             <p>{{ context }}</p>
         </sui-grid-column>
@@ -21,7 +24,22 @@
 export default {
     name: 'main-title',
     props: [
-        'title', 'limit_date', 'context'
+        'title', 'limit_date', 'context', 'type',
     ],
+    computed: {
+        unit_type() {
+            const { type } = this;
+            switch(type){
+                case 'EXAM' :
+                    return '구현 시험';
+                case 'HOMEWORK' :
+                    return '구현 과제';
+                case 'TRAIN' :
+                    return '구현 실습';
+                default :
+                    return '기타 항목';
+            }
+        }
+    }
 }
 </script>

--- a/src/components/main_problem/problem/MainTitle.vue
+++ b/src/components/main_problem/problem/MainTitle.vue
@@ -6,7 +6,7 @@
                     <sui-icon name="archive" />
                     <sui-header-content>
                         {{ title }}
-                        <sui-header-subheader>{{ type.label }}</sui-header-subheader>
+                        <sui-header-subheader>{{ unit_type.label }}</sui-header-subheader>
                     </sui-header-content>
                 </h1>
             </sui-grid-column>
@@ -15,7 +15,7 @@
                     <sui-icon name="bell outline" />
                     <sui-header-content>특이사항</sui-header-content>
                 </h1>
-                <p>{{ context }}</p>
+                <p>{{ description }}</p>
             </sui-grid-column>
         </sui-grid>
     </div>
@@ -24,9 +24,20 @@
 <script>
 export default {
     name: 'main-title',
-    props: [
-        'title', 'limit_date', 'context', 'type',
-    ]
+    props: {
+        title: {
+            type: String,
+            required: true
+        }, 
+        description: {
+            type: String,
+            required: false
+        },
+        unit_type: {
+            type: Object,
+            required: true
+        }
+    },
 }
 </script>
 

--- a/src/components/main_problem/problem/MainTitle.vue
+++ b/src/components/main_problem/problem/MainTitle.vue
@@ -6,17 +6,16 @@
                     <sui-icon name="archive" />
                     <sui-header-content>
                         {{ title }}
-                        <sui-header-subheader>{{ unit_type }}</sui-header-subheader>
+                        <sui-header-subheader>{{ type.label }}</sui-header-subheader>
                     </sui-header-content>
                 </h1>
-                <p>{{ context }}</p>
             </sui-grid-column>
             <sui-grid-column width="eight">
                 <h1 is="sui-header">
                     <sui-icon name="bell outline" />
-                    <sui-header-content>제출기한</sui-header-content>
+                    <sui-header-content>특이사항</sui-header-content>
                 </h1>
-                <p>{{ limit_date }}</p>
+                <p>{{ context }}</p>
             </sui-grid-column>
         </sui-grid>
     </div>
@@ -27,22 +26,7 @@ export default {
     name: 'main-title',
     props: [
         'title', 'limit_date', 'context', 'type',
-    ],
-    computed: {
-        unit_type() {
-            const { type } = this;
-            switch(type){
-                case 'EXAM' :
-                    return '구현 시험';
-                case 'HOMEWORK' :
-                    return '구현 과제';
-                case 'TRAIN' :
-                    return '구현 실습';
-                default :
-                    return '기타 항목';
-            }
-        }
-    }
+    ]
 }
 </script>
 

--- a/src/components/main_problem/problem/MainTitle.vue
+++ b/src/components/main_problem/problem/MainTitle.vue
@@ -1,23 +1,25 @@
 <template>
-    <sui-grid>
-        <sui-grid-column width="eight">
-            <h1 is="sui-header">
-                <sui-icon name="archive" />
-                <sui-header-content>
-                    {{ title }}
-                    <sui-header-subheader>{{ unit_type }}</sui-header-subheader>
-                </sui-header-content>
-            </h1>
-            <p>{{ context }}</p>
-        </sui-grid-column>
-        <sui-grid-column width="eight">
-            <h1 is="sui-header">
-                <sui-icon name="bell outline" />
-                <sui-header-content>제출기한</sui-header-content>
-            </h1>
-            <p>{{ limit_date }}</p>
-        </sui-grid-column>
-    </sui-grid>
+    <div id="main__title">
+        <sui-grid>
+            <sui-grid-column width="eight">
+                <h1 is="sui-header">
+                    <sui-icon name="archive" />
+                    <sui-header-content>
+                        {{ title }}
+                        <sui-header-subheader>{{ unit_type }}</sui-header-subheader>
+                    </sui-header-content>
+                </h1>
+                <p>{{ context }}</p>
+            </sui-grid-column>
+            <sui-grid-column width="eight">
+                <h1 is="sui-header">
+                    <sui-icon name="bell outline" />
+                    <sui-header-content>제출기한</sui-header-content>
+                </h1>
+                <p>{{ limit_date }}</p>
+            </sui-grid-column>
+        </sui-grid>
+    </div>
 </template>
 
 <script>
@@ -43,3 +45,9 @@ export default {
     }
 }
 </script>
+
+<style>
+#main__title {
+    margin: 30px 0px;
+}
+</style>

--- a/src/components/main_problem/problem/ScoreUnit.vue
+++ b/src/components/main_problem/problem/ScoreUnit.vue
@@ -1,0 +1,26 @@
+<template>
+    <sui-statistic size="tiny" floated="right">
+        <sui-statistic-label>
+            {{ time_confirm.checked ? '내 점수 / 만점' : '만점' }}
+        </sui-statistic-label>
+        <sui-statistic-value>
+            {{ time_confirm.checked ? `${ my_score }/${ full_score }` : full_score }}
+        </sui-statistic-value>
+        <div class="button__margin">
+            <sui-button :content="time_confirm.context" :color="time_confirm.color" @click="time_confirm.action" />
+        </div>
+    </sui-statistic>
+</template>
+
+<script>
+export default {
+    name: 'score-unit',
+    props: ['my_score', 'full_score', 'time_confirm']
+}
+</script>
+
+<style>
+.button__margin {
+    margin-top: 5px;
+}
+</style>

--- a/src/components/main_problem/problem/ScoreUnit.vue
+++ b/src/components/main_problem/problem/ScoreUnit.vue
@@ -1,13 +1,13 @@
 <template>
     <sui-statistic size="tiny" floated="right">
         <sui-statistic-label>
-            {{ checked ? '내 점수 / 만점' : '만점' }}
+            {{ score_props.label }}
         </sui-statistic-label>
         <sui-statistic-value>
-            {{ checked ? `${ my_score }/${ full_score }` : full_score }}
+            {{ score_props.context }}
         </sui-statistic-value>
         <div class="button__margin">
-            <sui-button :content="btn_data.context" :color="btn_data.color" @click="btn_data.action" />
+            <sui-button :content="btn_props.context" :color="btn_props.color" @click="btn_props.action" />
         </div>
     </sui-statistic>
 </template>
@@ -16,19 +16,11 @@
 export default {
     name: 'score-unit',
     props: {
-        my_score: {
-            type: Number,
+        score_props: {
+            type: Object,
             required: false
         },
-        full_score: {
-            type: Number,
-            required: true
-        },
-        checked: {
-            type: Boolean,
-            required: true
-        },
-        btn_data: {
+        btn_props: {
             type: Object,
             required: true
         }

--- a/src/components/main_problem/problem/ScoreUnit.vue
+++ b/src/components/main_problem/problem/ScoreUnit.vue
@@ -1,13 +1,13 @@
 <template>
     <sui-statistic size="tiny" floated="right">
         <sui-statistic-label>
-            {{ time_confirm.checked ? '내 점수 / 만점' : '만점' }}
+            {{ checked ? '내 점수 / 만점' : '만점' }}
         </sui-statistic-label>
         <sui-statistic-value>
-            {{ time_confirm.checked ? `${ my_score }/${ full_score }` : full_score }}
+            {{ checked ? `${ my_score }/${ full_score }` : full_score }}
         </sui-statistic-value>
         <div class="button__margin">
-            <sui-button :content="time_confirm.context" :color="time_confirm.color" @click="time_confirm.action" />
+            <sui-button :content="btn_data.context" :color="btn_data.color" @click="btn_data.action" />
         </div>
     </sui-statistic>
 </template>
@@ -15,7 +15,24 @@
 <script>
 export default {
     name: 'score-unit',
-    props: ['my_score', 'full_score', 'time_confirm']
+    props: {
+        my_score: {
+            type: Number,
+            required: false
+        },
+        full_score: {
+            type: Number,
+            required: true
+        },
+        checked: {
+            type: Boolean,
+            required: true
+        },
+        btn_data: {
+            type: Object,
+            required: true
+        }
+    }
 }
 </script>
 

--- a/src/components/main_problem/problem/TimeUploaderUnit.vue
+++ b/src/components/main_problem/problem/TimeUploaderUnit.vue
@@ -9,8 +9,21 @@
 
 <script>
 export default {
-    name: 'detail-unit',
-    props: ['checked', 'upload_cnt', 'reserve_date'],
+    name: 'time-uploader-unit',
+    props: {
+        checked: {
+            type: Boolean,
+            required: true,
+        },
+        upload_cnt: {
+            type: Number,
+            required: true,
+        },
+        reserve_date: {
+            type: Date,
+            required: true,
+        }
+    },
     computed: {
         output_context() {
             const { checked, upload_cnt, reserve_date } = this;

--- a/src/components/main_problem/problem/TimeUploaderUnit.vue
+++ b/src/components/main_problem/problem/TimeUploaderUnit.vue
@@ -1,8 +1,8 @@
 <template>
     <sui-header-subheader>
-        <sui-icon :name="output_context.icon" /> 
+        <sui-icon :name="uploader_props.icon_name" /> 
         <sui-header-content>
-            {{ output_context.context }}
+            {{ uploader_props.description }}
         </sui-header-content>
     </sui-header-subheader>
 </template>
@@ -11,35 +11,10 @@
 export default {
     name: 'time-uploader-unit',
     props: {
-        checked: {
-            type: Boolean,
-            required: true,
+        uploader_props: {
+            type: Object,
+            required: true
         },
-        upload_cnt: {
-            type: Number,
-            required: true,
-        },
-        reserve_date: {
-            type: Date,
-            required: true,
-        }
-    },
-    computed: {
-        output_context() {
-            const { checked, upload_cnt, reserve_date } = this;
-            const start_time = reserve_date.getTime() - 90 * 60 * 1000;
-            if(checked){
-                return {
-                    icon: 'users',
-                    context: `${ upload_cnt } 명 제출했습니다.`
-                };
-            } else {
-                return {
-                    icon: 'clock outline',
-                    context: `${ new Date(start_time).toLocaleString() } 부터 진행`
-                }
-            }
-        }
     }
 }
 </script>

--- a/src/pages/main_problem/MainProblemListPage.vue
+++ b/src/pages/main_problem/MainProblemListPage.vue
@@ -30,7 +30,6 @@ export default {
         return {
             examination: {
                 title: '1차 구현시험',
-                limit_date: new Date().toLocaleString(),
                 context: '실습, 과제, 시험에 대한 특이 사항을 기재합니다.',
                 type: {
                     value: 'EXAM', // TRAIN 은 실습, HOMEWORK 는 과제, EXAM 는 구현 시험입니다.
@@ -77,7 +76,7 @@ export default {
                         title: 'Python Lambda',
                         upload_cnt: 13,
                         full_score: 20,
-                        reserve_date: new Date(2019, 3, 21, 0, 0, 0),
+                        reserve_date: new Date(2019, 3, 21, 2, 30, 0),
                     },
                     {
                         id: 7,

--- a/src/pages/main_problem/MainProblemListPage.vue
+++ b/src/pages/main_problem/MainProblemListPage.vue
@@ -1,5 +1,6 @@
 <template>
     <div is="sui-container">
+        <top-breadthumb :subject=" '알고리즘' " :exam_title="examination.title"></top-breadthumb>
         <main-title 
             :type="examination.type"
             :title="examination.title"
@@ -11,13 +12,14 @@
 </template>
 
 <script>
+import TopBreadthumb from '@/components/main_problem/breadthumb/TopBreadthumb'
 import MainTitle from '@/components/main_problem/problem/MainTitle'
 import MainElement from '@/components/main_problem/problem/MainElement'
 
 export default {
     name: 'main-problem-list-page',
     components: {
-        MainTitle, MainElement
+        TopBreadthumb, MainTitle, MainElement
     },
     data() {
         return {
@@ -32,42 +34,49 @@ export default {
                         title: 'JAVA ArrayList',
                         upload_cnt: 10, // 이는 서버에서 제출한 사람의 수를 카운팅하여 반환하여 목록에서 보여줌을 가정하고 컴포넌트에 렌더링합니다.
                         full_score: 10,
+                        reserve_date: new Date(2019, 4, 17, 18, 0, 0),
                     },
                     {
                         id: 2,
                         title: 'JAVA Arrays',
                         upload_cnt: 12,
                         full_score: 10,
+                        reserve_date: new Date(2020, 4, 30, 18, 0, 0),
                     },
                     {
                         id: 3,
                         title: 'JS Prototype',
                         upload_cnt: 16,
                         full_score: 20,
+                        reserve_date: new Date(2019, 4, 17, 18, 0, 0),
                     },
                     {
                         id: 4,
                         title: 'JS Object',
                         upload_cnt: 19,
                         full_score: 20,
+                        reserve_date: new Date(2020, 4, 30, 18, 0, 0),
                     },
                     {
                         id: 5,
-                        title: 'JS Prototype',
+                        title: 'Python Dictionary',
                         upload_cnt: 21,
                         full_score: 20,
+                        reserve_date: new Date(2019, 4, 17, 18, 0, 0),
                     },
                     {
                         id: 6,
-                        title: 'JS Object',
+                        title: 'Python Lambda',
                         upload_cnt: 13,
                         full_score: 20,
+                        reserve_date: new Date(2019, 4, 17, 18, 0, 0),
                     },
                     {
                         id: 7,
                         title: '시험성적 확인전용 문제',
                         upload_cnt: 18,
                         full_score: 20,
+                        reserve_date: new Date(2020, 4, 30, 18, 0, 0),
                     }
                 ]
             }

--- a/src/pages/main_problem/MainProblemListPage.vue
+++ b/src/pages/main_problem/MainProblemListPage.vue
@@ -1,0 +1,32 @@
+<template>
+    <div is="sui-container">
+        <main-title 
+            :title="examination.title"
+            :limit_date="examination.limit_date"
+            :context="examination.context"
+        ></main-title>
+    </div>
+</template>
+
+<script>
+import MainTitle from '@/components/main_problem/problem/MainTitle'
+export default {
+    name: 'main-problem-list-page',
+    components: {
+        MainTitle
+    },
+    data() {
+        return {
+            examination: {
+                title: '1차 구현시험',
+                limit_date: new Date().toLocaleString(),
+                context: '실습, 과제, 시험에 대한 특이 사항을 기재합니다.',
+                problems: []
+            }
+        }
+    }
+}
+</script>
+
+<style>
+</style>

--- a/src/pages/main_problem/MainProblemListPage.vue
+++ b/src/pages/main_problem/MainProblemListPage.vue
@@ -7,7 +7,12 @@
             :limit_date="examination.limit_date"
             :context="examination.context"
         ></main-title>
-        <main-element :problem="problem" :key="problem.id" v-for="problem in examination.problems"></main-element>
+        <main-element 
+            :key="problem.id"
+            :problem="problem" 
+            :type="examination.type" 
+            v-for="problem in examination.problems"
+        ></main-element>
     </div>
 </template>
 
@@ -27,56 +32,56 @@ export default {
                 title: '1차 구현시험',
                 limit_date: new Date().toLocaleString(),
                 context: '실습, 과제, 시험에 대한 특이 사항을 기재합니다.',
-                type: 'TRAIN', // TRAIN 은 실습, HOMEWORK 는 과제, EXAM 는 구현 시험입니다.
+                type: 'EXAM', // TRAIN 은 실습, HOMEWORK 는 과제, EXAM 는 구현 시험입니다.
                 problems: [ // problems 는 소단락 문제(일명 새끼 문제)들 목록입니다.
                     {
                         id: 1,
                         title: 'JAVA ArrayList',
                         upload_cnt: 10, // 이는 서버에서 제출한 사람의 수를 카운팅하여 반환하여 목록에서 보여줌을 가정하고 컴포넌트에 렌더링합니다.
                         full_score: 10,
-                        reserve_date: new Date(2019, 4, 17, 18, 0, 0),
+                        reserve_date: new Date(2019, 3, 17, 18, 0, 0),
                     },
                     {
                         id: 2,
                         title: 'JAVA Arrays',
                         upload_cnt: 12,
                         full_score: 10,
-                        reserve_date: new Date(2020, 4, 30, 18, 0, 0),
+                        reserve_date: new Date(2020, 3, 30, 18, 0, 0),
                     },
                     {
                         id: 3,
                         title: 'JS Prototype',
                         upload_cnt: 16,
                         full_score: 20,
-                        reserve_date: new Date(2019, 4, 17, 18, 0, 0),
+                        reserve_date: new Date(2019, 3, 17, 18, 0, 0),
                     },
                     {
                         id: 4,
                         title: 'JS Object',
                         upload_cnt: 19,
                         full_score: 20,
-                        reserve_date: new Date(2020, 4, 30, 18, 0, 0),
+                        reserve_date: new Date(2020, 3, 30, 18, 0, 0),
                     },
                     {
                         id: 5,
                         title: 'Python Dictionary',
                         upload_cnt: 21,
                         full_score: 20,
-                        reserve_date: new Date(2019, 4, 17, 18, 0, 0),
+                        reserve_date: new Date(2019, 3, 17, 18, 0, 0),
                     },
                     {
                         id: 6,
                         title: 'Python Lambda',
                         upload_cnt: 13,
                         full_score: 20,
-                        reserve_date: new Date(2019, 4, 17, 18, 0, 0),
+                        reserve_date: new Date(2019, 3, 21, 0, 0, 0),
                     },
                     {
                         id: 7,
                         title: '시험성적 확인전용 문제',
                         upload_cnt: 18,
                         full_score: 20,
-                        reserve_date: new Date(2020, 4, 30, 18, 0, 0),
+                        reserve_date: new Date(2020, 3, 30, 18, 0, 0),
                     }
                 ]
             }

--- a/src/pages/main_problem/MainProblemListPage.vue
+++ b/src/pages/main_problem/MainProblemListPage.vue
@@ -1,19 +1,23 @@
 <template>
     <div is="sui-container">
         <main-title 
+            :type="examination.type"
             :title="examination.title"
             :limit_date="examination.limit_date"
             :context="examination.context"
         ></main-title>
+        <main-element :problem="problem" :key="problem.id" v-for="problem in examination.problems"></main-element>
     </div>
 </template>
 
 <script>
 import MainTitle from '@/components/main_problem/problem/MainTitle'
+import MainElement from '@/components/main_problem/problem/MainElement'
+
 export default {
     name: 'main-problem-list-page',
     components: {
-        MainTitle
+        MainTitle, MainElement
     },
     data() {
         return {
@@ -21,7 +25,51 @@ export default {
                 title: '1차 구현시험',
                 limit_date: new Date().toLocaleString(),
                 context: '실습, 과제, 시험에 대한 특이 사항을 기재합니다.',
-                problems: []
+                type: 'TRAIN', // TRAIN 은 실습, HOMEWORK 는 과제, EXAM 는 구현 시험입니다.
+                problems: [ // problems 는 소단락 문제(일명 새끼 문제)들 목록입니다.
+                    {
+                        id: 1,
+                        title: 'JAVA ArrayList',
+                        upload_cnt: 10, // 이는 서버에서 제출한 사람의 수를 카운팅하여 반환하여 목록에서 보여줌을 가정하고 컴포넌트에 렌더링합니다.
+                        full_score: 10,
+                    },
+                    {
+                        id: 2,
+                        title: 'JAVA Arrays',
+                        upload_cnt: 12,
+                        full_score: 10,
+                    },
+                    {
+                        id: 3,
+                        title: 'JS Prototype',
+                        upload_cnt: 16,
+                        full_score: 20,
+                    },
+                    {
+                        id: 4,
+                        title: 'JS Object',
+                        upload_cnt: 19,
+                        full_score: 20,
+                    },
+                    {
+                        id: 5,
+                        title: 'JS Prototype',
+                        upload_cnt: 21,
+                        full_score: 20,
+                    },
+                    {
+                        id: 6,
+                        title: 'JS Object',
+                        upload_cnt: 13,
+                        full_score: 20,
+                    },
+                    {
+                        id: 7,
+                        title: '시험성적 확인전용 문제',
+                        upload_cnt: 18,
+                        full_score: 20,
+                    }
+                ]
             }
         }
     }

--- a/src/pages/main_problem/MainProblemListPage.vue
+++ b/src/pages/main_problem/MainProblemListPage.vue
@@ -32,7 +32,10 @@ export default {
                 title: '1차 구현시험',
                 limit_date: new Date().toLocaleString(),
                 context: '실습, 과제, 시험에 대한 특이 사항을 기재합니다.',
-                type: 'EXAM', // TRAIN 은 실습, HOMEWORK 는 과제, EXAM 는 구현 시험입니다.
+                type: {
+                    value: 'EXAM', // TRAIN 은 실습, HOMEWORK 는 과제, EXAM 는 구현 시험입니다.
+                    label: '구현시험'
+                },
                 problems: [ // problems 는 소단락 문제(일명 새끼 문제)들 목록입니다.
                     {
                         id: 1,

--- a/src/pages/main_problem/MainProblemListPage.vue
+++ b/src/pages/main_problem/MainProblemListPage.vue
@@ -2,15 +2,14 @@
     <div is="sui-container">
         <top-breadthumb :subject=" '알고리즘' " :exam_title="examination.title"></top-breadthumb>
         <main-title 
-            :type="examination.type"
             :title="examination.title"
-            :limit_date="examination.limit_date"
-            :context="examination.context"
+            :unit_type="examination.unit_type"
+            :description="examination.description"
         ></main-title>
         <main-element 
             :key="problem.id"
-            :problem="problem" 
-            :type="examination.type" 
+            :type_code="examination.unit_type.value"
+            :problem="problem"  
             v-for="problem in examination.problems"
         ></main-element>
     </div>
@@ -30,8 +29,8 @@ export default {
         return {
             examination: {
                 title: '1차 구현시험',
-                context: '실습, 과제, 시험에 대한 특이 사항을 기재합니다.',
-                type: {
+                description: '실습, 과제, 시험에 대한 특이 사항을 기재합니다.',
+                unit_type: {
                     value: 'EXAM', // TRAIN 은 실습, HOMEWORK 는 과제, EXAM 는 구현 시험입니다.
                     label: '구현시험'
                 },
@@ -41,7 +40,7 @@ export default {
                         title: 'JAVA ArrayList',
                         upload_cnt: 10, // 이는 서버에서 제출한 사람의 수를 카운팅하여 반환하여 목록에서 보여줌을 가정하고 컴포넌트에 렌더링합니다.
                         full_score: 10,
-                        reserve_date: new Date(2019, 3, 17, 18, 0, 0),
+                        reserve_date: new Date(2019, 3, 27, 16, 0, 0), // 제출 제한 기간은 문제 별로 다르게 책정했습니다. 제출 기한 날짜 별 Component State 를 확인하기 위함입니다.
                     },
                     {
                         id: 2,
@@ -75,7 +74,7 @@ export default {
                         id: 6,
                         title: 'Python Lambda',
                         upload_cnt: 13,
-                        full_score: 20,
+                        full_score: 10,
                         reserve_date: new Date(2019, 3, 21, 2, 30, 0),
                     },
                     {


### PR DESCRIPTION
- 상단부에 Breadthumb 와 문제 간략 정보를 조회할 수 있도록 구현함.
- 문제 목록에서 정보를 다르게 뒀음. 시험 이전이면 시험 시각, 이후면 제출 인원을 표기했음.
- 버튼 색상을 제출 기한에 따라 다르게 설정하였음.
- 데이터를 서버에서 받아옴을 가정하에 구현해서 서버 파트와 조율을 쉽게 할 수 있을 듯함.
- 미리보기는 카톡방을 참고하시길 바랍니다.